### PR TITLE
Update env template and docs for Supabase setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,4 +71,4 @@ jobs:
       - uses: codespell-project/actions-codespell@v2
         with:
           ignore_words_file: .codespellignore
-          path: apps/src
+          path: apps/web/src

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Yes! It requires some modifications to be made to the code, but we've implemente
 
 No. All agents you intend to use with OAP must be LangGraph agents, deployed on LangGraph Platform.
 
-### Why is my agent's config is only showing string inputs, and not custom fields?
+### Why is my agent's config only showing string inputs, and not custom fields?
 
 First, ensure you're using the latest version of LangGraph. If running locally, make sure you're using the latest version of the LangGraph API, and CLI packages. If deploying, make sure you've published a revision after 05/14/2025. Then, check that you have the `x_oap_ui_config` metadata set on your configurable fields. If you have, check that your configurable object is defined using LangGraph Zod (if using TypeScript), as this is required for the Open Agent Platform to recognize & render your UI fields.
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -28,3 +28,10 @@ NEXT_PUBLIC_SUPABASE_URL=""
 # Disable showing Google Auth in the UI
 # Defaults to false.
 # NEXT_PUBLIC_GOOGLE_AUTH_DISABLED=false
+
+# Enable demo mode banner
+NEXT_PUBLIC_DEMO_APP="false"
+
+# Optional MCP server token for testing. JSON string with an access_token field
+# Example: MCP_TOKENS='{"access_token":"abc123"}'
+MCP_TOKENS=""

--- a/apps/web/src/providers/Agents.tsx
+++ b/apps/web/src/providers/Agents.tsx
@@ -157,7 +157,7 @@ type AgentsContextType = {
    */
   loading: boolean;
   /**
-   * Whether the agents list is currently loading.
+   * Whether the agents list is currently refreshing.
    */
   refreshAgentsLoading: boolean;
 };


### PR DESCRIPTION
## Summary
- clarify grammar in README FAQ
- fix CI spelling check path
- update comment on `refreshAgentsLoading`
- extend `.env.example` with demo and MCP token variables

## Testing
- `yarn lint` *(fails: FetchError: Connect Timeout Error)*
- `yarn format:check` *(fails: EHOSTUNREACH)*

## Summary by Sourcery

Update CI workflow, documentation, and environment template for Supabase setup

Enhancements:
- Add DEMO_API_TOKEN and MCP_TOKEN placeholders to .env.example

CI:
- Fix codespell spellcheck path to apps/web/src in CI workflow

Documentation:
- Clarify grammar in README FAQ
- Refine description of refreshAgentsLoading in Agents provider comment

---
## EntelligenceAI PR Summary 
 - CI workflow now lints 'apps/web/src' instead of 'apps/src'
- README FAQ header grammar corrected
- apps/web/.env.example updated with new demo/testing variables and improved comments
- JSDoc in apps/web/src/providers/Agents.tsx clarified for 'refreshAgentsLoading' 

