### PR TITLE
Implement interrupts and streamline hooks

### DIFF
--- a/apps/web/src/components/agent-inbox/contexts/utils.ts
+++ b/apps/web/src/components/agent-inbox/contexts/utils.ts
@@ -2,18 +2,6 @@ import { Thread, ThreadState } from "@langchain/langgraph-sdk";
 import { HumanInterrupt, ThreadData } from "../types";
 import { IMPROPER_SCHEMA } from "../constants";
 
-// TODO: Delete this once interrupt issue fixed.
-export const tmpCleanInterrupts = (interrupts: Record<string, any[]>) => {
-  return Object.fromEntries(
-    Object.entries(interrupts).map(([k, v]) => {
-      if (Array.isArray(v[0] && v[0]?.[1])) {
-        return [k, v?.[0][1]];
-      }
-      return [k, v];
-    }),
-  );
-};
-
 export function getInterruptFromThread(
   thread: Thread,
 ): HumanInterrupt[] | undefined {

--- a/apps/web/src/features/agents/components/agent-dashboard/index.tsx
+++ b/apps/web/src/features/agents/components/agent-dashboard/index.tsx
@@ -160,7 +160,7 @@ export function AgentDashboard() {
       )}
 
       <EditAgentDialog
-        agent={filteredAgents[0]}
+        agent={filteredAgents.length > 0 ? filteredAgents[0] : undefined}
         open={showCreateDialog}
         onOpenChange={setShowCreateDialog}
       />

--- a/apps/web/src/features/agents/components/agent-dashboard/index.tsx
+++ b/apps/web/src/features/agents/components/agent-dashboard/index.tsx
@@ -12,7 +12,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { AgentCard } from "../agent-card";
-import { CreateAgentDialog } from "../create-edit-agent-dialogs/create-agent-dialog";
+import { EditAgentDialog } from "../create-edit-agent-dialogs/edit-agent-dialog";
 import { useAgentsContext } from "@/providers/Agents";
 import { getDeployments } from "@/lib/environment/deployments";
 import { GraphGroup } from "../../types";
@@ -159,8 +159,8 @@ export function AgentDashboard() {
         </div>
       )}
 
-      {/* TODO: Replace with EditAgentDialog */}
-      <CreateAgentDialog
+      <EditAgentDialog
+        agent={filteredAgents[0]}
         open={showCreateDialog}
         onOpenChange={setShowCreateDialog}
       />

--- a/apps/web/src/features/chat/components/thread-history-sidebar/index.tsx
+++ b/apps/web/src/features/chat/components/thread-history-sidebar/index.tsx
@@ -153,7 +153,6 @@ export const ThreadHistorySidebar = forwardRef<
                         </p>
                       </div>
                     </div>
-                    {/* TODO: Add save/delete buttons back if needed */}
                   </div>
                 );
               })}

--- a/apps/web/src/features/chat/components/thread/index.tsx
+++ b/apps/web/src/features/chat/components/thread/index.tsx
@@ -219,11 +219,10 @@ export function Thread() {
     dragOver,
     handlePaste,
   } = useFileUpload();
-  const [firstTokenReceived, setFirstTokenReceived] = useState(false);
-
   const { session } = useAuthContext();
 
   const stream = useStreamContext();
+  const { firstTokenReceived, setFirstTokenReceived } = stream;
   const messages = stream.messages;
   const isLoading = stream.isLoading;
 
@@ -260,19 +259,6 @@ export function Thread() {
     }
   }, [stream.error]);
 
-  // TODO: this should be part of the useStream hook
-  const prevMessageLength = useRef(0);
-  useEffect(() => {
-    if (
-      messages.length !== prevMessageLength.current &&
-      messages?.length &&
-      messages[messages.length - 1].type === "ai"
-    ) {
-      setFirstTokenReceived(true);
-    }
-
-    prevMessageLength.current = messages.length;
-  }, [messages]);
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -337,8 +323,6 @@ export function Thread() {
     if (!agentId) return;
     const { getAgentConfig } = useConfigStore.getState();
 
-    // Do this so the loading state is correct
-    prevMessageLength.current = prevMessageLength.current - 1;
     setFirstTokenReceived(false);
     stream.submit(undefined, {
       checkpoint: parentCheckpoint,

--- a/apps/web/src/features/chat/components/thread/messages/ai.tsx
+++ b/apps/web/src/features/chat/components/thread/messages/ai.tsx
@@ -10,6 +10,7 @@ import { ToolCalls, ToolResult } from "./tool-calls";
 import { MessageContentComplex } from "@langchain/core/messages";
 import { Fragment } from "react/jsx-runtime";
 import { useQueryState, parseAsBoolean } from "nuqs";
+import { GenericInterruptValue } from "@/components/agent-inbox/components/generic-interrupt-value";
 
 function CustomComponent({
   message,
@@ -103,6 +104,13 @@ export function AssistantMessage({
     );
   const hasAnthropicToolCalls = !!anthropicStreamedToolCalls?.length;
   const isToolResult = message?.type === "tool";
+  const messages = thread.messages;
+  const threadInterrupt = thread.interrupt;
+  const isLastMessage =
+    messages.length > 0 && messages[messages.length - 1] === message;
+  const hasNoAIOrToolMessages = !messages.find(
+    (m) => m.type === "ai" || m.type === "tool",
+  );
 
   if (isToolResult && hideToolCalls) {
     return null;
@@ -138,19 +146,13 @@ export function AssistantMessage({
               thread={thread}
             />
           )}
-          {/**
-           * TODO: Support rendering interrupts.
-           * Tracking issue: https://github.com/langchain-ai/open-agent-platform/issues/22
-           */}
-          {/* {isAgentInboxInterruptSchema(threadInterrupt?.value) &&
-            (isLastMessage || hasNoAIOrToolMessages) && (
-              <ThreadView interrupt={threadInterrupt.value} />
-            )}
           {threadInterrupt?.value &&
-          !isAgentInboxInterruptSchema(threadInterrupt.value) &&
-          isLastMessage ? (
-            <GenericInterruptView interrupt={threadInterrupt.value} />
-          ) : null} */}
+            (isLastMessage || hasNoAIOrToolMessages) && (
+              <GenericInterruptValue
+                interrupt={threadInterrupt.value}
+                id={threadInterrupt.when ?? "interrupt"}
+              />
+            )}
           <div
             className={cn(
               "mr-auto flex items-center gap-2 transition-opacity",


### PR DESCRIPTION
## Summary
- render interrupts in `AssistantMessage`
- remove defunct save/delete controls
- streamline message length effect by integrating it into `useStream`
- swap placeholder for `EditAgentDialog`
- drop unused `tmpCleanInterrupts` helper

## Testing
- `yarn lint`
- `yarn test` *(fails: command not found)*

## Summary by Sourcery

Implement interrupt rendering in chat threads, relocate first-token streaming logic into the useStream hook, remove unused helpers and UI placeholders, and update the agent dashboard to use EditAgentDialog.

New Features:
- Render thread interrupts in AssistantMessage using GenericInterruptValue.
- Replace CreateAgentDialog placeholder with EditAgentDialog in the agent dashboard.

Enhancements:
- Move first-token detection for streamed messages into the useStream hook by adding firstTokenReceived state.
- Remove redundant prevMessageLength logic and first-token effect from the Thread component.
- Remove defunct save/delete controls in thread history and drop the unused tmpCleanInterrupts helper.

---
## EntelligenceAI PR Summary 
 This PR refactors agent and chat components for improved state management and code clarity.
- Centralizes 'firstTokenReceived' state in Stream context (thread/index.tsx, providers/Stream.tsx)
- Updates AgentDashboard to use EditAgentDialog (agent-dashboard/index.tsx)
- Refactors interrupt rendering in AssistantMessage (messages/ai.tsx)
- Removes obsolete utility and comments (utils.ts, thread-history-sidebar/index.tsx) 

